### PR TITLE
publish ground truth pose from gazebo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,19 @@ ASL Turtlebot 3 ROS2 utility packages
 TODO
 
 ## F.A.Q.
-- When I run Gazebo a bunch of errors print that say ``[ruby $(which gz) sim-2] [Err] [SDFFeatures.cc:843] The geometry element of collision [left_hand] couldn't be created``, should I be worried?
-   - These are a known issue with Gazebo, and are safe to ignore.
+1. When I run Gazebo a bunch of errors print that say ``[ruby $(which gz) sim-2] [Err] [SDFFeatures.cc:843] The geometry element of collision [left_hand] couldn't be created``, should I be worried?
 
+    These are a known issue with Gazebo, and are safe to ignore.
+
+2. If Gazebo cannot find model uri, e.g. the terminal throws the following error
+    ```
+    ... Msg: Unable to find uri[model://asl_tb3_sim/models/turtlebot3_world]
+    ```
+
+    You need to rebuild `tb_ws` and make sure to include the environment variable `GZ_VERSION=garden`.
+    To do a clean rebuild, run the following command in a terminal.
+
+    ```sh
+    cd ~/tb_ws && rm -r build install log
+    GZ_VERSION=garden colcon build --symlink-install
+    ```

--- a/asl_tb3_sim/configs/gz_bridge.yaml
+++ b/asl_tb3_sim/configs/gz_bridge.yaml
@@ -34,3 +34,8 @@
   ros_type_name: "tf2_msgs/msg/TFMessage"
   gz_type_name: "gz.msgs.Pose_V"
   direction: GZ_TO_ROS
+- ros_topic_name: "/sim/pose"
+  gz_topic_name: "/model/asl_tb3/pose"
+  ros_type_name: "geometry_msgs/msg/PoseStamped"
+  gz_type_name: "gz.msgs.Pose"
+  direction: GZ_TO_ROS

--- a/asl_tb3_sim/models/asl_tb3.sdf
+++ b/asl_tb3_sim/models/asl_tb3.sdf
@@ -406,5 +406,12 @@
       <joint_name>left_wheel_joint</joint_name>
       <joint_name>right_wheel_joint</joint_name>
     </plugin>
+
+    <!-- ground truth pose -->
+    <plugin filename="gz-sim-pose-publisher-system" name="gz::sim::systems::PosePublisher">
+      <publish_nested_model_pose>true</publish_nested_model_pose>
+      <publish_link_pose>false</publish_link_pose>
+      <update_frequency>20</update_frequency>
+    </plugin>
   </model>
 </sdf>


### PR DESCRIPTION
Ground truth turtlebot pose from gazebo is now published to `/sim/pose`.

**Note**: our autonomy stack should **not** use this channel since it is not available on hardware.