### PR TITLE
replan collision check start from timestep 1

### DIFF
--- a/asl_tb3_lib/asl_tb3_lib/control.py
+++ b/asl_tb3_lib/asl_tb3_lib/control.py
@@ -79,6 +79,10 @@ class BaseController(Node):
         twist.angular.z = np.clip(control.omega, -om_max, om_max)
         self.cmd_vel_pub.publish(twist)
 
+    def stop(self) -> None:
+        """ send zero control to stop the robot """
+        self.cmd_vel_pub.publish(Twist())
+
     def can_compute_control(self) -> bool:
         """ Check whether or not control can be computed at the current time
 

--- a/asl_tb3_lib/asl_tb3_lib/navigation.py
+++ b/asl_tb3_lib/asl_tb3_lib/navigation.py
@@ -200,7 +200,7 @@ class BaseNavigator(BaseController):
         )
 
         # replan if the new map updates causes collision in the original plan
-        if self.is_planned and not all([self.occupancy.is_free(s) for s in self.plan.path]):
+        if self.is_planned and not all([self.occupancy.is_free(s) for s in self.plan.path[1:]]):
             self.is_planned = False
             self.replan(self.goal)
 

--- a/asl_tb3_lib/asl_tb3_lib/navigation.py
+++ b/asl_tb3_lib/asl_tb3_lib/navigation.py
@@ -133,6 +133,10 @@ class BaseNavigator(BaseController):
             self.switch_mode(NavMode.PARK)
             return
 
+        # stop the robot before planning with A* as it can take quite long to finish
+        self.stop()
+
+        # plan with A*
         new_plan = self.compute_trajectory_plan(
             state=self.state,
             goal=goal,
@@ -140,15 +144,19 @@ class BaseNavigator(BaseController):
             resolution=self.get_parameter("plan_resolution").value,
             horizon=self.get_parameter("plan_horizon").value,
         )
+
+        # planning failed
         if new_plan is None:
             self.is_planned = False
             self.get_logger().warn("Replanning failed")
             return
 
+        # planning succeeded
         self.is_planned = True
         self.plan = new_plan
         self.get_logger().info(f"Replanned to {goal}")
 
+        # publish planned and smoothed trajectory for visualization in RVIZ
         self.publish_planned_path()
         self.publish_smooth_path()
 


### PR DESCRIPTION
Replanning due to collision check was too frequent when robot gets close to an obstacle. Removing the collision check on the current state to mitigate this problem.

Also stop the robot when running A* as it can take long and it is not safe for the robot to move during planning.